### PR TITLE
Support cluster-scoped resource

### DIFF
--- a/cmd/kubectl-tree/rootcmd.go
+++ b/cmd/kubectl-tree/rootcmd.go
@@ -115,7 +115,13 @@ func run(command *cobra.Command, args []string) error {
 	ns := getNamespace()
 	klog.V(2).Infof("namespace=%s allNamespaces=%v", ns, allNs)
 
-	obj, err := dyn.Resource(api.GroupVersionResource()).Namespace(ns).Get(name, metav1.GetOptions{})
+	var ri dynamic.ResourceInterface
+	if api.r.Namespaced {
+		ri = dyn.Resource(api.GroupVersionResource()).Namespace(ns)
+	} else {
+		ri = dyn.Resource(api.GroupVersionResource())
+	}
+	obj, err := ri.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get %s/%s: %w", kind, name, err)
 	}


### PR DESCRIPTION
This PR fixes https://github.com/ahmetb/kubectl-tree/issues/26 .

Output after applying this change.

```bash
$ kubectl tree samples sample -A
NAMESPACE     NAME                               READY  REASON  AGE
              Sample/sample                -              112s
              ├─ClusterRole/sample         -              111s
              ├─ClusterRoleBinding/sample  -              111s
test          └─ServiceAccount/sample      -              112s
```