### PR TITLE
feat: accept KIND/NAME form

### DIFF
--- a/cmd/kubectl-tree/apis.go
+++ b/cmd/kubectl-tree/apis.go
@@ -113,3 +113,20 @@ func apiNames(a metav1.APIResource, gv schema.GroupVersion) []string {
 	}
 	return out
 }
+
+func figureOutKindName(args []string) (string, string, error) {
+	if l := len(args); l == 0 || l > 2 {
+		return "", "", fmt.Errorf("accepts between 1 and 2 arg(s), received %d", l)
+	}
+	if len(args) == 2 {
+		return args[0], args[1], nil
+	}
+	seg := strings.Split(args[0], "/")
+	if len(seg) < 2 {
+		return "", "", fmt.Errorf("specify the kubernetes object in KIND NAME or KIND/NAME form")
+	}
+	if len(seg) > 2 {
+		return "", "", fmt.Errorf("arguments in KIND/NAME form may not have more than one slash")
+	}
+	return seg[0], seg[1], nil
+}

--- a/cmd/kubectl-tree/rootcmd.go
+++ b/cmd/kubectl-tree/rootcmd.go
@@ -47,7 +47,7 @@ var rootCmd = &cobra.Command{
 	Short:        "Show sub-resources of the Kubernetes object",
 	Example: "  kubectl tree deployment my-app\n" +
 		"  kubectl tree kservice.v1.serving.knative.dev my-app", // TODO add more examples about disambiguation etc
-	Args:    cobra.MinimumNArgs(2),
+	Args:    cobra.RangeArgs(1, 2),
 	RunE:    run,
 	Version: versionString(),
 }
@@ -90,7 +90,10 @@ func run(command *cobra.Command, args []string) error {
 	}
 	klog.V(3).Info("completed querying APIs list")
 
-	kind, name := args[0], args[1]
+	kind, name, err := figureOutKindName(args)
+	if err != nil {
+		return err
+	}
 	klog.V(3).Infof("parsed kind=%v name=%v", kind, name)
 
 	var api apiResource


### PR DESCRIPTION
#40, accept both KIND NAME or KIND/NAME form to specify the Kubernetes object

e.g. `kubectl tree deployment my-app`, `kubectl tree deployment/my-app`