### PR TITLE
Fix confusion with duplicate names

### DIFF
--- a/cmd/kubectl-tree/apis.go
+++ b/cmd/kubectl-tree/apis.go
@@ -100,9 +100,16 @@ func apiNames(a metav1.APIResource, gv schema.GroupVersion) []string {
 		// TODO(ahmetb): sometimes SingularName is empty (e.g. Deployment), use lowercase Kind as fallback - investigate why
 		singularName = strings.ToLower(a.Kind)
 	}
+	names := []string{singularName}
+
 	pluralName := a.Name
+	if singularName != pluralName {
+		names = append(names, pluralName)
+	}
+
 	shortNames := a.ShortNames
-	names := append([]string{singularName, pluralName}, shortNames...)
+	names = append(names, shortNames...)
+
 	for _, n := range names {
 		fmtBare := n                                                                // e.g. deployment
 		fmtWithGroup := strings.Join([]string{n, gv.Group}, ".")                    // e.g. deployment.apps


### PR DESCRIPTION
When a kind reports the same name for its singular and its plural version then kubectl-tree gets confused and there's no way for a user to query the tree for that specific kind.

With this commit, kubectl-tree eliminates duplicates in its internal list of names for a particular kind so that there's always an unambiguous way to specify which kind to query.

closes #64