### PR TITLE
ignore discovery errors

### DIFF
--- a/cmd/kubectl-tree/apis.go
+++ b/cmd/kubectl-tree/apis.go
@@ -46,7 +46,7 @@ func findAPIs(client discovery.DiscoveryInterface) (*resourceMap, error) {
 	start := time.Now()
 	resList, err := client.ServerPreferredResources()
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch api groups from kubernetes: %w", err)
+		klog.V(1).Infof("failed to fetch api groups from kubernetes: %v\n", err)
 	}
 	klog.V(2).Infof("queried api discovery in %v", time.Since(start))
 	klog.V(3).Infof("found %d items (groups) in server-preferred APIResourceList", len(resList))


### PR DESCRIPTION
Currently, it fails when any of the api-resources is failing but this should only be a warning, and there is no need to block the tree to proceed given we print some warnings about the error.

Current version:
```
$ kubectl  tree --version
kubectl version v0.4.3

$ kubectl tree StatefulSet/matst-gn7lu2-monitor
Error: failed to fetch api groups from kubernetes: unable to retrieve the complete list of server APIs: data.packaging.carvel.dev/v1alpha1: the server is currently unable to handle the request
```

With this PR:
```
$ ./kubectl-tree StatefulSet/matst-gn7lu2-monitor
E1208 00:07:06.589076 2603851 memcache.go:287] couldn't get resource list for data.packaging.carvel.dev/v1alpha1: the server is currently unable to handle the request
E1208 00:07:06.762539 2603851 memcache.go:121] couldn't get resource list for data.packaging.carvel.dev/v1alpha1: the server is currently unable to handle the request
NAMESPACE  NAME                                                  READY  REASON  AGE
default    StatefulSet/matst-gn7lu2-monitor                      -              59m
default    ├─ControllerRevision/matst-gn7lu2-monitor-55895d466c  -              59m
default    └─Pod/matst-gn7lu2-monitor-0                          True           59m
```

I just logged the error rather than printing it to the stderr as client-go already prints the warnings ootb as you can see above. But if you run it with `-v 1`, you can still see the relevant error:
```
$ ./kubectl-tree -v1 StatefulSet/matst-gn7lu2-monitor
E1208 00:06:56.769060 2603504 memcache.go:287] couldn't get resource list for data.packaging.carvel.dev/v1alpha1: the server is currently unable to handle the request
E1208 00:06:56.941860 2603504 memcache.go:121] couldn't get resource list for data.packaging.carvel.dev/v1alpha1: the server is currently unable to handle the request
I1208 00:06:56.942236 2603504 apis.go:49] failed to fetch api groups from kubernetes: unable to retrieve the complete list of server APIs: data.packaging.carvel.dev/v1alpha1: the server is currently unable to handle the request
NAMESPACE  NAME                                                  READY  REASON  AGE
default    StatefulSet/matst-gn7lu2-monitor                      -              59m
default    ├─ControllerRevision/matst-gn7lu2-monitor-55895d466c  -              59m
default    └─Pod/matst-gn7lu2-monitor-0                          True           59m

```