### PR TITLE
feat: filter resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Example (Agones Fleet):
 By default, the plugin searches only namespaced objects in the same namespace
 as the specified object.
 
-Tree-specific flags:
-
 - `-A`, `--all-namespaces`: Search namespaced and non-namespaced objects in all namespaces.
 
 - `-n`, `--namespace`: Namespace scope for the CLI request.
@@ -56,30 +54,19 @@ Tree-specific flags:
 
 - `--condition-types`: Comma-separated list of condition types to check. Default: `Ready`. Example: `Ready,Processed,Scheduled`.
 
-- `--api-groups`: Comma-separated list of API groups to include in the query. When not set, all API groups are included. Supports globs. Example: `--api-groups=core,cluster.x-k8s.io,*.cert-manager.io`.
+- `--api-groups`: Comma-separated list of API groups to include in the query. When not set, all API groups are included. Supports globs. Example: `--api-groups=core,*cluster.x-k8s.io,!addons.*,*.cert-manager.io`.
 
 - `--resources`: Comma-separated list of resource types to include in the query. When not set, all resources are included. Supports globs. Example: `--resources=deployments,rs,pods`.
 
-  Resource filters accept kind, singular, plural, and short names. For example, `ReplicaSets`, `replicasets`, `replicaset`, and `rs` all match the same resource.
-  Globs are also supported, for example `*sets`.
+  Resource filters accept kind, singular, plural, and short names. For example, `ReplicaSets`, `replicasets`, `replicaset`, and `rs` all match the same resource type.
 
-Both `--resources` and `--api-groups` support glob matching and can narrow the APIs and resources included while building the tree. This can significantly reduce workload and data usage in large clusters.
+Using `--resources` and `--api-groups` to define what APIs and resources are included or excluded while building the tree can significantly reduce workload and data usage in large clusters.
 If an intermediate owner resource is filtered out, traversal stops at that point and child resources below it will be missing, even if the leaf resource or API would otherwise match.
 For example, using `--resources=deployments,pods` will return nothing because `replicasets` are not included and `pods` are not directly owned by `deployments`.
-
-Globs can be negated by prefixing a `!`, for example:
 
 ```sh
 kubectl tree --api-groups '*.custom.api,*cluster.x-k8s.io' --resources '!customresource' cluster my-cluster
 ```
-
-Inherited `kubectl` flags:
-
-- `-h`, `--help`: Show command help.
-
-- Standard `kubectl` client and authentication flags are also supported, including `--kubeconfig`, `--context`, `--cluster`, `--user`, `--server`, `--token`, `--as`, `--as-group`, `--as-uid`, `--as-user-extra`, `--certificate-authority`, `--client-certificate`, `--client-key`, `--tls-server-name`, `--insecure-skip-tls-verify`, `--request-timeout`, `--disable-compression`, and `--cache-dir`.
-
-- `-v`: Set log verbosity level.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ Example (Agones Fleet):
 
 ## Flags
 
-By default, the plugin will only search "namespaced" objects in the same
-namespace as the specified object.
+By default, the plugin searches only namespaced objects in the same namespace
+as the specified object.
+
+Tree-specific flags:
 
 - `-A`, `--all-namespaces`: Search namespaced and non-namespaced objects in all namespaces.
+
+- `-n`, `--namespace`: Namespace scope for the CLI request.
+
+- `-c`, `--color`: Control color output. Supported values are `always`, `never`, and `auto` (default).
 
 - `-l`, `--selector`: Selector (label query) to filter on. Supports equality (`=`, `==`, `!=`), set-based (`in`, `notin`), and existence operators. Examples:
   - `-l key1=value1,key2=value2` (equality)
@@ -48,7 +54,32 @@ namespace as the specified object.
 
   This helps reduce workload and data volume when working with large clusters.
 
-- `--condition-types`: Comma-separated list of condition types to check (default: Ready). Example: `Ready,Processed,Scheduled`.
+- `--condition-types`: Comma-separated list of condition types to check. Default: `Ready`. Example: `Ready,Processed,Scheduled`.
+
+- `--api-groups`: Comma-separated list of API groups to include in the query. When not set, all API groups are included. Supports globs. Example: `--api-groups=core,cluster.x-k8s.io,*.cert-manager.io`.
+
+- `--resources`: Comma-separated list of resource types to include in the query. When not set, all resources are included. Supports globs. Example: `--resources=deployments,rs,pods`.
+
+  Resource filters accept kind, singular, plural, and short names. For example, `ReplicaSets`, `replicasets`, `replicaset`, and `rs` all match the same resource.
+  Globs are also supported, for example `*sets`.
+
+Both `--resources` and `--api-groups` support glob matching and can narrow the APIs and resources included while building the tree. This can significantly reduce workload and data usage in large clusters.
+If an intermediate owner resource is filtered out, traversal stops at that point and child resources below it will be missing, even if the leaf resource or API would otherwise match.
+For example, using `--resources=deployments,pods` will return nothing because `replicasets` are not included and `pods` are not directly owned by `deployments`.
+
+Globs can be negated by prefixing a `!`, for example:
+
+```sh
+kubectl tree --api-groups '*.custom.api,*cluster.x-k8s.io' --resources '!customresource' cluster my-cluster
+```
+
+Inherited `kubectl` flags:
+
+- `-h`, `--help`: Show command help.
+
+- Standard `kubectl` client and authentication flags are also supported, including `--kubeconfig`, `--context`, `--cluster`, `--user`, `--server`, `--token`, `--as`, `--as-group`, `--as-uid`, `--as-user-extra`, `--certificate-authority`, `--client-certificate`, `--client-key`, `--tls-server-name`, `--insecure-skip-tls-verify`, `--request-timeout`, `--disable-compression`, and `--cache-dir`.
+
+- `-v`: Set log verbosity level.
 
 ## Author
 

--- a/cmd/kubectl-tree/apis.go
+++ b/cmd/kubectl-tree/apis.go
@@ -82,9 +82,6 @@ func matchAny(patterns []string, match func(string) (bool, error)) bool {
 
 func matchGroups(patterns []string, g string) bool {
 	return matchAny(patterns, func(pattern string) (bool, error) {
-		if pattern == "*" {
-			return true, nil
-		}
 		if pattern == "core" || pattern == "" {
 			return g == "", nil
 		}

--- a/cmd/kubectl-tree/apis.go
+++ b/cmd/kubectl-tree/apis.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -43,7 +44,74 @@ func fullAPIName(a apiResource) string {
 	return strings.Join([]string{sgv.Resource, sgv.Version, sgv.Group}, ".")
 }
 
-func findAPIs(client discovery.DiscoveryInterface, apiGroups []string) (*resourceMap, error) {
+func matchAny(patterns []string, match func(string) (bool, error)) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+
+	hasPositive := false
+	matchedPositive := false
+
+	for _, p := range patterns {
+		negated := strings.HasPrefix(p, "!")
+		if negated {
+			p = p[1:]
+		} else {
+			hasPositive = true
+		}
+
+		ok, err := match(p)
+		if err != nil {
+			klog.V(1).Infof("%s is an invalid pattern: %v", p, err)
+			continue
+		}
+		if negated && ok {
+			return false
+		}
+		if !negated && ok {
+			matchedPositive = true
+		}
+	}
+
+	return !hasPositive || matchedPositive
+}
+
+func matchGroups(patterns []string, g string) bool {
+	return matchAny(patterns, func(pattern string) (bool, error) {
+		if pattern == "*" {
+			return true, nil
+		}
+		if pattern == "core" || pattern == "" {
+			return g == "", nil
+		}
+
+		return filepath.Match(pattern, g)
+	})
+}
+
+func matchResources(patterns []string, apiRes metav1.APIResource) bool {
+	if apiRes.SingularName == "" {
+		apiRes.SingularName = strings.ToLower(apiRes.Kind)
+	}
+	names := []string{apiRes.Name, apiRes.SingularName, apiRes.Kind}
+	names = append(names, apiRes.ShortNames...)
+
+	return matchAny(patterns, func(pattern string) (bool, error) {
+		for _, name := range names {
+			ok, err := filepath.Match(pattern, name)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+}
+
+func findAPIs(client discovery.DiscoveryInterface, apiGroups, resources []string) (*resourceMap, error) {
 	start := time.Now()
 	resList, err := client.ServerPreferredResources()
 	if err != nil {
@@ -61,16 +129,9 @@ func findAPIs(client discovery.DiscoveryInterface, apiGroups []string) (*resourc
 			return nil, fmt.Errorf("%q cannot be parsed into groupversion: %w", group.GroupVersion, err)
 		}
 
-		if len(apiGroups) != 0 {
-			if !slices.ContainsFunc(apiGroups, func(g string) bool {
-				if g == "core" || g == "" {
-					return gv.Group == ""
-				}
-				return gv.Group == g
-			}) {
-				klog.V(5).Infof("ignoring group %s/%s (%d apis)", group.GroupVersion, group.APIVersion, len(group.APIResources))
-				continue
-			}
+		if !matchGroups(apiGroups, gv.Group) {
+			klog.V(5).Infof("ignoring group %s/%s (%d apis)", group.GroupVersion, group.APIVersion, len(group.APIResources))
+			continue
 		}
 		klog.V(5).Infof("iterating over group %s/%s (%d apis)", group.GroupVersion, group.APIVersion, len(group.APIResources))
 
@@ -78,6 +139,12 @@ func findAPIs(client discovery.DiscoveryInterface, apiGroups []string) (*resourc
 			klog.V(5).Infof("  api=%s namespaced=%v", apiRes.Name, apiRes.Namespaced)
 			if !contains(apiRes.Verbs, "list") {
 				klog.V(4).Infof("    api (%s) doesn't have required verb, skipping: %v", apiRes.Name, apiRes.Verbs)
+				continue
+			}
+			// NOTE: if a intermediate owner is excluded that will break the chain, even if the leaf is included
+			// for example --resources=deployments,pods will return nothing because replicasets are not included
+			if !matchResources(resources, apiRes) {
+				klog.V(5).Infof("    api (%s) doesn't match any resource pattern, skipping: %v", apiRes.Name, apiRes.Verbs)
 				continue
 			}
 			v := apiResource{

--- a/cmd/kubectl-tree/apis.go
+++ b/cmd/kubectl-tree/apis.go
@@ -49,8 +49,7 @@ func matchAny(patterns []string, match func(string) (bool, error)) bool {
 		return true
 	}
 
-	hasPositive := false
-	matchedPositive := false
+	var hasPositive, matchedPositive bool
 
 	for _, p := range patterns {
 		negated := strings.HasPrefix(p, "!")
@@ -66,13 +65,18 @@ func matchAny(patterns []string, match func(string) (bool, error)) bool {
 			continue
 		}
 		if negated && ok {
+			// if a netagive expression is matched we return immediately
 			return false
 		}
 		if !negated && ok {
+			// if a positive expression is matched,
+			// we take note of it but continue the loop, in case there are any netagive expressions that would match
 			matchedPositive = true
 		}
 	}
 
+	// if there are only negatives, allow by default unless a negative matched earlier
+	// if there are positives, require at least one positive match
 	return !hasPositive || matchedPositive
 }
 

--- a/cmd/kubectl-tree/apis_test.go
+++ b/cmd/kubectl-tree/apis_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMatchGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		value    string
+		want     bool
+	}{
+		{name: "empty patterns", value: "apps", want: true},
+		{name: "positive match", patterns: []string{"apps"}, value: "apps", want: true},
+		{name: "positive miss", patterns: []string{"apps"}, value: "batch", want: false},
+		{name: "negative match excluded", patterns: []string{"!batch"}, value: "batch", want: false},
+		{name: "negative miss included", patterns: []string{"!batch"}, value: "apps", want: true},
+		{name: "positive and negative", patterns: []string{"*", "!batch"}, value: "batch", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchGroups(tt.patterns, tt.value); got != tt.want {
+				t.Fatalf("matchAny(%v, %q) = %v, want %v", tt.patterns, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchResources(t *testing.T) {
+	apiRes := metav1.APIResource{
+		Name:         "pods",
+		SingularName: "pod",
+		Kind:         "Pod",
+		ShortNames:   []string{"po"},
+	}
+
+	tests := []struct {
+		name     string
+		patterns []string
+		want     bool
+	}{
+		{name: "exclude plural excludes resource", patterns: []string{"!pods"}, want: false},
+		{name: "exclude singular excludes resource", patterns: []string{"!pod"}, want: false},
+		{name: "exclude short name excludes resource", patterns: []string{"!po"}, want: false},
+		{name: "positive include works", patterns: []string{"pods"}, want: true},
+		{name: "positive and negative prefers exclusion", patterns: []string{"*", "!po"}, want: false},
+		{name: "negative unrelated keeps resource", patterns: []string{"!deployments"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchResources(tt.patterns, apiRes); got != tt.want {
+				t.Fatalf("matchResources(%v, %v) = %v, want %v", tt.patterns, apiRes.Name, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/kubectl-tree/apis_test.go
+++ b/cmd/kubectl-tree/apis_test.go
@@ -15,6 +15,8 @@ func TestMatchGroups(t *testing.T) {
 	}{
 		{name: "empty patterns", value: "apps", want: true},
 		{name: "positive match", patterns: []string{"apps"}, value: "apps", want: true},
+		{name: "positive glob match", patterns: []string{"app*"}, value: "apps", want: true},
+		{name: "positive glob miss", patterns: []string{"app*"}, value: "batch", want: false},
 		{name: "positive miss", patterns: []string{"apps"}, value: "batch", want: false},
 		{name: "negative match excluded", patterns: []string{"!batch"}, value: "batch", want: false},
 		{name: "negative miss included", patterns: []string{"!batch"}, value: "apps", want: true},

--- a/cmd/kubectl-tree/rootcmd.go
+++ b/cmd/kubectl-tree/rootcmd.go
@@ -42,6 +42,7 @@ const (
 	conditionTypesFlag = "condition-types"
 	selectorFlag       = "selector"
 	apiGroupsFlag      = "api-groups"
+	resourcesFlag      = "resources"
 )
 
 var (
@@ -107,6 +108,11 @@ func run(command *cobra.Command, args []string) error {
 		return err
 	}
 
+	resources, err := command.Flags().GetStringSlice(resourcesFlag)
+	if err != nil {
+		return err
+	}
+
 	restConfig, err := cf.ToRESTConfig()
 	if err != nil {
 		return err
@@ -123,7 +129,7 @@ func run(command *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to construct discovery client: %w", err)
 	}
 
-	apis, err := findAPIs(dc, apiGroups)
+	apis, err := findAPIs(dc, apiGroups, resources)
 	if err != nil {
 		return err
 	}
@@ -229,7 +235,8 @@ func init() {
 	rootCmd.Flags().StringP(colorFlag, "c", "auto", "Enable or disable color output. This can be 'always', 'never', or 'auto' (default = use color only if using tty). The flag is overridden by the NO_COLOR env variable if set.")
 	rootCmd.Flags().StringSlice(conditionTypesFlag, []string{"Ready"}, "Comma-separated list of condition types to check (default: Ready). Example: Ready,Processed,Scheduled")
 	rootCmd.Flags().StringP(selectorFlag, "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='. (e.g. -l key1=value1,key2=value2)")
-	rootCmd.Flags().StringSlice(apiGroupsFlag, nil, "Comma-separated list of API groups to include in the query, when not set all APIs are included (e.g. --api-groups=core,cluster.x-k8s.io,acme.cert-manager.io)")
+	rootCmd.Flags().StringSlice(apiGroupsFlag, nil, "Comma-separated list of API groups to include in the query, when not set all APIs are included, globs are supported (e.g. --api-groups=core,cluster.x-k8s.io,*.cert-manager.io)")
+	rootCmd.Flags().StringSlice(resourcesFlag, nil, "Comma-separated list of resource types to include in the query, when not set all resources are included, globs are supported (e.g. --resources=deployments,pods)")
 
 	cf.AddFlags(rootCmd.Flags())
 	if err := flag.Set("logtostderr", "true"); err != nil {

--- a/cmd/kubectl-tree/rootcmd.go
+++ b/cmd/kubectl-tree/rootcmd.go
@@ -236,7 +236,7 @@ func init() {
 	rootCmd.Flags().StringSlice(conditionTypesFlag, []string{"Ready"}, "Comma-separated list of condition types to check (default: Ready). Example: Ready,Processed,Scheduled")
 	rootCmd.Flags().StringP(selectorFlag, "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='. (e.g. -l key1=value1,key2=value2)")
 	rootCmd.Flags().StringSlice(apiGroupsFlag, nil, "Comma-separated list of API groups to include in the query, when not set all APIs are included, globs are supported (e.g. --api-groups=core,cluster.x-k8s.io,*.cert-manager.io)")
-	rootCmd.Flags().StringSlice(resourcesFlag, nil, "Comma-separated list of resource types to include in the query, when not set all resources are included, globs are supported (e.g. --resources=deployments,pods)")
+	rootCmd.Flags().StringSlice(resourcesFlag, nil, "Comma-separated list of resource types to include in the query, when not set all resources are included, globs are supported (e.g. --resources=deployments,rs,pods)")
 
 	cf.AddFlags(rootCmd.Flags())
 	if err := flag.Set("logtostderr", "true"); err != nil {


### PR DESCRIPTION
This is a followup on #113 

It extends the functionality in 2 ways, it allows using glob patterns and it also allows filtering the resources.

there's an edge case noted in the code, if an intermediate owner is filtered out, it breaks the traversal but I think it's up to the user to know what they are doing, the main reason for this is performance and not to filter what's displayed.

This solves the main case that made me open these PRs in the first place. I have clusters with very large numbers of some resources that I don't need to query for the trees I'm interested in, the same command before this PR would take more than 3 minutes to complete and with it takes about 3 seconds.

my use case is something like:

```
go run ./cmd/kubectl-tree --api-groups '*.custom.api,*cluster.x-k8s.io' --resources '!customresource' otherresource foo
```